### PR TITLE
✨ Feat: 다운로드 진행도 확인 추가 (SSE)

### DIFF
--- a/backend/routes/file.js
+++ b/backend/routes/file.js
@@ -16,6 +16,15 @@ router.post("/upload/data", uploadMiddleware, (req, res) => {
     res.json({ header: req.file });
 });
 
+// SSE 엔드포인트 연결 설정, 다운로드 진행도(%) 확인
+router.get("/getDownloadProgress", (req, res) => {
+    try {
+        DataTransferService.getDownloadProgress(req, res)
+    } catch (error) {
+        res.status(500).send(error.message);
+    }
+});
+
 // ZIP 파일 생성 및 다운로드, 
 router.post("/download", async (req, res) => {
     try {

--- a/backend/services/filetransferservice.js
+++ b/backend/services/filetransferservice.js
@@ -52,7 +52,7 @@ class DataTransferService {
     static async downloadZip(body) {
         const { objectIDs, downloadFileRoot } = body; // 요청에서 ObjectID 리스트 가져오기
         const files = await FileModel.find({ _id: { $in: objectIDs } });
-        const filePaths = files.map(file => file.f_root);
+        const filePaths = files.map(file => file.f_path);
         //const { filePaths, downloadFileRoot } = body;           // 파일 루트 리스트 받았을 때 사용했었음
 
         const zip = new JSZip();


### PR DESCRIPTION
응답  형식
{
    "type": "ftpUpload",
    "filename": "output.zip",
    "transferred": 4804,
    "total": 4804,
    "percentage": 100
}
-> 스토리지에서 FTP서버 업로드 진행도 확인

{
    "type": "download",
    "filename": "output.zip",
    "transferred": 4804,
    "total": 4804,
    "percentage": 100
}
-> FTP서버에서 클라이언트로의 다운로드 진행도 확인